### PR TITLE
add search by 2,3 letter codes; tests; readme

### DIFF
--- a/Country.cs
+++ b/Country.cs
@@ -4,8 +4,12 @@
  * Data source: http://en.wikipedia.org/wiki/ISO_3166-1
  * License: http://creativecommons.org/licenses/by-sa/3.0/
  */
+
 namespace ISO3166
 {
+    using System;
+    using System.Collections.Generic;
+
     public class Country
     {
         public string Name { get; private set; }
@@ -273,5 +277,42 @@ namespace ISO3166
             new Country("Zambia", "ZM", "ZMB", "894"),
             new Country("Zimbabwe", "ZW", "ZWE", "716"),
         };
+
+
+        static Country()
+        {
+            // fill search structures
+            foreach (var country in List)
+            {
+                Code2Dict.Add(country.TwoLetterCode, country);
+                Code3Dict.Add(country.ThreeLetterCode, country);
+            }
+        }
+
+        private static readonly IDictionary<string, Country> Code2Dict =
+            new Dictionary<string, Country>();
+
+        private static readonly IDictionary<string, Country> Code3Dict =
+            new Dictionary<string, Country>();
+
+        public static Country FindBy2Code(string twoLetterCode)
+        {
+            if (twoLetterCode == null)
+                throw new ArgumentNullException("twoLetterCode");
+            
+            Country res;
+            Code2Dict.TryGetValue(twoLetterCode.ToUpper(), out res);
+            return res;
+        }
+
+        public static Country FindBy3Code(string threeLetterCode)
+        {
+            if (threeLetterCode == null)
+                throw new ArgumentNullException("threeLetterCode");
+
+            Country res;
+            Code3Dict.TryGetValue(threeLetterCode.ToUpper(), out res);
+            return res;
+        }
     }
 }

--- a/ISO3166.sln
+++ b/ISO3166.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ISO3166", "ISO3166.csproj", "{E8A7EDEB-7E49-4297-BC45-90E98E0D5329}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ISO3166.Tests", "tests\ISO3166.Tests\ISO3166.Tests.csproj", "{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E8A7EDEB-7E49-4297-BC45-90E98E0D5329}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8A7EDEB-7E49-4297-BC45-90E98E0D5329}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8A7EDEB-7E49-4297-BC45-90E98E0D5329}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8A7EDEB-7E49-4297-BC45-90E98E0D5329}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+#ISO 3166-1 country codes
+ 
+Data source: http://en.wikipedia.org/wiki/ISO_3166-1
+License: http://creativecommons.org/licenses/by-sa/3.0/
+
+
+##Example of usage:
+
+```c#
+Country[] allCountries = Country.List;
+Console.WriteLine("{0};{1};{2};{3}",
+  allCountries[0].TwoLetterCode,
+  allCountries[0].ThreeLetterCode,
+  allCountries[0].Name,
+  allCountries[0].NumericCode);
+Country greatBritain = Country.FindBy2Code("GB");
+Country france = Country.FindBy3Code("FRA");
+```
+
+The output is:
+```
+AF;AFG;Afghanistan;004
+```

--- a/tests/ISO3166.Tests/FindTests.cs
+++ b/tests/ISO3166.Tests/FindTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ISO3166.Tests
+{
+    [TestClass]
+    public class FindTests
+    {
+        [TestMethod]
+        public void FindBy2Code_ExistingLowercase_ReturnsMatch()
+        {
+            var country = Country.FindBy2Code("gb");
+            Assert.IsNotNull(country);
+            Assert.AreEqual("GB", country.TwoLetterCode);
+        }
+
+        [TestMethod]
+        public void FindBy2Code_ExistingUppercase_ReturnsMatch()
+        {
+            var country = Country.FindBy2Code("US");
+            Assert.IsNotNull(country);
+            Assert.AreEqual("US", country.TwoLetterCode);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void FindBy2Code_Blank_Throws()
+        {
+            Country.FindBy2Code(null);
+        }
+
+        [TestMethod]
+        public void FindBy2Code_Nonexisting_ReturnsNull()
+        {
+            var country = Country.FindBy2Code("zz");
+            Assert.IsNull(country);
+        }
+
+        [TestMethod]
+        public void FindBy3Code_ExistingLowercase_ReturnsMatch()
+        {
+            var country = Country.FindBy3Code("uKr");
+            Assert.IsNotNull(country);
+            Assert.AreEqual("UKR", country.ThreeLetterCode);
+        }
+
+        [TestMethod]
+        public void FindBy3Code_ExistingUppercase_ReturnsMatch()
+        {
+            var country = Country.FindBy3Code("SWE");
+            Assert.IsNotNull(country);
+            Assert.AreEqual("SWE", country.ThreeLetterCode);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void FindBy3Code_Blank_Throws()
+        {
+            Country.FindBy3Code(null);
+        }
+
+        [TestMethod]
+        public void FindBy3Code_Nonexisting_ReturnsNull()
+        {
+            var country = Country.FindBy3Code("zzz");
+            Assert.IsNull(country);
+        }
+    }
+}

--- a/tests/ISO3166.Tests/ISO3166.Tests.csproj
+++ b/tests/ISO3166.Tests/ISO3166.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4D14E1D7-36F0-444C-9BDF-A500FDDECC9B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ISO3166.Tests</RootNamespace>
+    <AssemblyName>ISO3166.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="FindTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ISO3166.csproj">
+      <Project>{e8a7edeb-7e49-4297-bc45-90e98e0d5329}</Project>
+      <Name>ISO3166</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/ISO3166.Tests/Properties/AssemblyInfo.cs
+++ b/tests/ISO3166.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ISO3166.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ISO3166.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("758f9782-b086-4d52-8a5f-fa7ca9ac65bb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
while working with the library i had a task to find a letter 3 code by letter 2 code, and vice versa.
So I thought it may be useful to add such case-insensitive lookup functions: `FindBy2Code`, `FindBy3Code`.

Implementation - library is still on .net 2.0, so I was not able to do it with Linq, and done with internal dictionaries instead.