### PR TITLE
Check date

### DIFF
--- a/Country.cs
+++ b/Country.cs
@@ -1,7 +1,7 @@
 ﻿/*
  * ISO 3166-1 country codes
  *
- * Data source: http://en.wikipedia.org/wiki/ISO_3166-1
+ * Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020.
  * License: http://creativecommons.org/licenses/by-sa/3.0/
  */
 namespace ISO3166

--- a/Country.cs
+++ b/Country.cs
@@ -24,7 +24,6 @@ namespace ISO3166
         public static readonly Country[] List = new[]
         {
             new Country("Afghanistan", "AF", "AFG", "004"),
-            new Country("Åland Islands", "AX", "ALA", "248"),
             new Country("Albania", "AL", "ALB", "008"),
             new Country("Algeria", "DZ", "DZA", "012"),
             new Country("American Samoa", "AS", "ASM", "016"),
@@ -272,6 +271,7 @@ namespace ISO3166
             new Country("Yemen", "YE", "YEM", "887"),
             new Country("Zambia", "ZM", "ZMB", "894"),
             new Country("Zimbabwe", "ZW", "ZWE", "716"),
+            new Country("Åland Islands", "AX", "ALA", "248")            
         };
     }
 }

--- a/ISO3166.csproj
+++ b/ISO3166.csproj
@@ -7,7 +7,7 @@
     <Description>
 ISO 3166-1 is part of the ISO 3166 standard published by the International Organization for Standardization (ISO), and defines codes for the names of countries, dependent territories, and special areas of geographical interest.
 This package provides a list of countries including their official English name as well as their ISO 3166 defined two-letter, three-letter and three-digit country codes. The list is accessible for any .NET language via the static field ISO3166.Country.List.
-Data source: Wikipedia.
+Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020.
     </Description>
     <PackageLicenseUrl>http://creativecommons.org/licenses/by-sa/3.0/</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/schourode/iso3166</PackageProjectUrl>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ public string NumericCode { get; private set; }
 public static readonly Country[] List = new[] {...};
 ```
 
-Data source: http://en.wikipedia.org/wiki/ISO_3166-1
-
 Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020
 
 License: CC BY-SA 3.0

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ public static readonly Country[] List = new[] {...};
 ```
 
 Data source: http://en.wikipedia.org/wiki/ISO_3166-1
+
 Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020
 
 License: CC BY-SA 3.0

--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ public static readonly Country[] List = new[] {...};
 ```
 
 Data source: http://en.wikipedia.org/wiki/ISO_3166-1
+Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020
 
 License: CC BY-SA 3.0


### PR DESCRIPTION
Added date when I checked the code against the official ISO 3166-1
It adds the value as saying: this is from Wikipedia, does not sound really assuring and there is really nothing special in checking this against the official content.
I think the package should not mention Wikipedia at all.