### PR TITLE
.NET Standard 2.0 support

### DIFF
--- a/ISO3166.csproj
+++ b/ISO3166.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net20;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard1.0;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>ISO 3166-1 Country codes</AssemblyTitle>
     <Title>ISO 3166-1 Country list</Title>
     <Authors>Jørn Schou-Rode</Authors>


### PR DESCRIPTION
Fixes #19 


See also

> We recommend you target .NET Standard 2.0, unless you need to support an earlier version. 

https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0