### PR TITLE
Sourcelink and deterministic build

### DIFF
--- a/ISO3166.csproj
+++ b/ISO3166.csproj
@@ -13,6 +13,8 @@ Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#searc
     <PackageProjectUrl>https://github.com/schourode/iso3166</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>iso3166 country</PackageTags>
+    <RepositoryUrl>https://github.com/schourode/iso3166.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <AssemblyDescription>Codes for the representation of names of countries.</AssemblyDescription>
     <Version>1.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -22,4 +24,10 @@ Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#searc
     <!-- EmbedUntrackedSources for deterministic build -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/ISO3166.csproj
+++ b/ISO3166.csproj
@@ -19,5 +19,7 @@ Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#searc
     <AssemblyOriginatorKeyFile>ISO3166.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <!-- EmbedUntrackedSources for deterministic build -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,6 @@ configuration: Release
 build_script:
 - ps: |-
     msbuild /t:Restore
-    msbuild ISO3166.sln /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=$Env:CONFIGURATION /p:TreatWarningsAsErrors=true
+    msbuild ISO3166.sln /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=$Env:CONFIGURATION /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=true
 artifacts:
 - path: '**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: build-{build}
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2022
 configuration: Release
 build_script:
 - ps: |-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ configuration: Release
 build_script:
 - ps: |-
     msbuild /t:Restore
-    msbuild ISO3166.sln /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=$Env:CONFIGURATION /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=true
+    msbuild ISO3166.sln /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /p:Configuration=$Env:CONFIGURATION /p:TreatWarningsAsErrors=true /p:ContinuousIntegrationBuild=true /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg
 artifacts:
 - path: '**\*.nupkg'
+- path: '**\*.snupkg'


### PR DESCRIPTION
Fixes #23 

- [x] sourcelink package and info
- [x] build flags for deterministic build 
- [x] snupkg for sourcelink 

PS: Updated to VS2022, we needed at least VS2019, but VS2022 looks better to me