### PR TITLE
Updating country name for Türkiye (formerly Turkey)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ obj/
 _ReSharper*/
 [Tt]est[Rr]esult*
 *.nupkg
+.vs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated country name from Turkey to Türkiye (TR, TUR, 792)
+
 ## [1.0.4] - 2022-05-19
 
 ### Added

--- a/Country.cs
+++ b/Country.cs
@@ -1,7 +1,7 @@
 ﻿/*
  * ISO 3166-1 country codes
  *
- * Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 8th January 2020.
+ * Last check against the official ISO 3166 as on https://www.iso.org/obp/ui/#search: 26th October 2024.
  */
 namespace ISO3166
 {
@@ -248,7 +248,7 @@ namespace ISO3166
             new Country("Tonga", "TO", "TON", "776"),
             new Country("Trinidad and Tobago", "TT", "TTO", "780"),
             new Country("Tunisia", "TN", "TUN", "788"),
-            new Country("Turkey", "TR", "TUR", "792"),
+            new Country("Türkiye", "TR", "TUR", "792"),
             new Country("Turkmenistan", "TM", "TKM", "795"),
             new Country("Turks and Caicos Islands", "TC", "TCA", "796"),
             new Country("Tuvalu", "TV", "TUV", "798"),
@@ -270,7 +270,7 @@ namespace ISO3166
             new Country("Yemen", "YE", "YEM", "887"),
             new Country("Zambia", "ZM", "ZMB", "894"),
             new Country("Zimbabwe", "ZW", "ZWE", "716"),
-            new Country("Åland Islands", "AX", "ALA", "248")            
+            new Country("Åland Islands", "AX", "ALA", "248")
         };
     }
 }


### PR DESCRIPTION
Update to stay consistent with official ISO names.
Fixes currently opened issue https://github.com/schourode/iso3166/issues/33 - ISO3166 TUR is not updated